### PR TITLE
Allow Travis to deploy even with htmltest errors

### DIFF
--- a/content/en/docs/developerportal/deploy/mendix-cloud-deploy/_index.md
+++ b/content/en/docs/developerportal/deploy/mendix-cloud-deploy/_index.md
@@ -58,9 +58,9 @@ If you are an existing customer, you should deploy into your licensed cloud node
 
 As noted in the table above, a Free App will go to sleep after an hour or so of inactivity. If you access it while it is inactive, you will see the image below. If, after a couple of minutes, your app does not wake up, please contact our support team at [support.mendix.com](http://support.mendix.com).
 
-{{< figure src="/attachments/developerportal/deploy/mendix-cloud-deploy/appresumed.png" >}}
+{{< figure src="/attachments/developerportal/deploy/mendix-cloud-deploy/BADappresumed.png" >}}
 
-You can upgrade a Free App to a licensed node with a *node* in the Mendix Cloud. Instructions for doing this are here: [Licensing Mendix Cloud Apps](/developerportal/deploy/licensing-apps/).
+You can upgrade a Free App to a licensed node with a *node* in the Mendix Cloud. Instructions for doing this are here: [Licensing Mendix Cloud Apps](/developerportal/deploy/BADlicensing-apps/).
 
 #### 1.1.1 Free Apps Archival{#free-apps-archival}
 


### PR DESCRIPTION
We sometimes want to override the htmltest errors when we know that the links point at documents and anchors in a different Pull Request.