### PR TITLE
Fix breadcrumb background

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -50,6 +50,7 @@ $code-color: darken($secondary, 20%) !default;
 
 // UI element colors
 
+$breadcrumb-bg: $white !default; // NK - added to override Docsy grey
 $border-color: $gray-200 !default; // NK - changed to better align to Figma Docs mockup
 $td-sidebar-tree-root-color: $secondary !default; // NK - switched top left nav bar link and line color to secondary
 $td-sidebar-bg-color: $gray-light !default;//rgba($primary, 0.03) !default;


### PR DESCRIPTION
In newer Docsy versions Bootstrap uses this variable to change background color of breadcrumb to grey. Overriding to white. Can be merged, regardless of Docsy version.